### PR TITLE
[FEAT] 이미지 업로드 및 api 호출

### DIFF
--- a/src/apis/createTales.ts
+++ b/src/apis/createTales.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+
+const baseURL = import.meta.env.VITE_PUBLIC_SERVER_URL;
+
+export const createWithImg = async (body: FormData): Promise<string[]> => {
+  try {
+    const response = await axios.post(`${baseURL}/tale/keyword`, body, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    alert("동화 생성 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    throw error;
+  }
+};

--- a/src/apis/settings.ts
+++ b/src/apis/settings.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+
+export const Server = axios.create({
+  baseURL: import.meta.env.VITE_PUBLIC_SERVER_URL,
+  timeout: 3000,
+  headers: { "Content-Type": "application/json" },
+});
+
+Server.interceptors.request.use(
+  (config) => {
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+Server.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);

--- a/src/components/common/tabBar/TabBar.tsx
+++ b/src/components/common/tabBar/TabBar.tsx
@@ -24,7 +24,7 @@ const TabBar = () => {
       <S.Margin />
       <S.TabBarContainer>
         {tabs.map((tab) => (
-          <S.TabWrapper>
+          <S.TabWrapper key={tab.id}>
             <S.TabCircle
               key={tab.id}
               isSelected={selectedTab === tab.id}

--- a/src/components/tales/createMain/CreateMain.styled.ts
+++ b/src/components/tales/createMain/CreateMain.styled.ts
@@ -34,6 +34,11 @@ export const SelectContainer = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+  @media (max-width: 600px) {
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    max-height: 100%;
+  }
 `;
 
 export const OptionContainer = styled.div`
@@ -42,4 +47,8 @@ export const OptionContainer = styled.div`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
+  @media (max-width: 600px) {
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
 `;

--- a/src/components/tales/createMain/SelectOption/InputImg.tsx
+++ b/src/components/tales/createMain/SelectOption/InputImg.tsx
@@ -1,0 +1,25 @@
+import { ChangeEvent } from "react";
+import * as S from "./SelectOption.styled";
+import { createWithImg } from "../../../../apis/createTales";
+
+const InputImg = () => {
+  const insertImg = (e: ChangeEvent<HTMLInputElement>) => {
+    let reader = new FileReader();
+    const file = e.target.files?.[0];
+    const formData = new FormData();
+    if (file) {
+      formData.append("file", file);
+      const result = createWithImg(formData);
+    }
+  };
+  return (
+    <S.ImgInput
+      id="imageInput"
+      type="file"
+      accept="image/*"
+      onChange={(e) => insertImg(e)}
+    />
+  );
+};
+
+export default InputImg;

--- a/src/components/tales/createMain/SelectOption/InputImg.tsx
+++ b/src/components/tales/createMain/SelectOption/InputImg.tsx
@@ -4,12 +4,13 @@ import { createWithImg } from "../../../../apis/createTales";
 
 const InputImg = () => {
   const insertImg = (e: ChangeEvent<HTMLInputElement>) => {
-    let reader = new FileReader();
+    new FileReader();
     const file = e.target.files?.[0];
     const formData = new FormData();
     if (file) {
       formData.append("file", file);
       const result = createWithImg(formData);
+      console.log(result);
     }
   };
   return (

--- a/src/components/tales/createMain/SelectOption/SelectOption.styled.ts
+++ b/src/components/tales/createMain/SelectOption/SelectOption.styled.ts
@@ -16,13 +16,23 @@ export const Wrapper = styled.div`
     font-size: 1.7rem;
     font-weight: 700;
   }
+  cursor: pointer;
 `;
 
-export const box = styled.div`
+export const ImgBox = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   img {
     width: 55%;
   }
+`;
+
+export const ImgInput = styled.input`
+  display: none;
+`;
+
+export const ImgLabel = styled.label`
+  height: 250px;
+  width: 220px;
 `;

--- a/src/components/tales/createMain/SelectOption/SelectOption.tsx
+++ b/src/components/tales/createMain/SelectOption/SelectOption.tsx
@@ -1,15 +1,30 @@
 import { SelectOptionProps } from "@type/selectOption";
 import * as S from "./SelectOption.styled";
+import InputImg from "./InputImg";
 
 const SelectOption = ({ text, imgURL }: SelectOptionProps) => {
-  return (
-    <S.Wrapper>
-      <S.box>
-        <img src={imgURL} />
-      </S.box>
-      <div>{text} 만들기</div>
-    </S.Wrapper>
-  );
+  if (text.includes("사진")) {
+    return (
+      <S.ImgLabel htmlFor="imageInput">
+        <S.Wrapper>
+          <InputImg />
+          <S.ImgBox>
+            <img src={imgURL} />
+          </S.ImgBox>
+          <div>{text} 만들기</div>
+        </S.Wrapper>
+      </S.ImgLabel>
+    );
+  } else {
+    return (
+      <S.Wrapper>
+        <S.ImgBox>
+          <img src={imgURL} />
+        </S.ImgBox>
+        <div>{text} 만들기</div>
+      </S.Wrapper>
+    );
+  }
 };
 
 export default SelectOption;


### PR DESCRIPTION
### 👀 관련 이슈
- Resolve : #13 
### ✨ 작업한 내용
- 이미지 업로드 컴포넌트 분리
- 이미지 post api 호출
- axios http 요청 및 응답 처리

### 🌀 PR Point
- 이미지 업로드 해서 받은 키워드들을 전부 props로 넘겨서 키워드 선택 페이지에서 받아올 생각인데, 괜찮겠죠? 더 좋은 방법이 있을지 같이 고민해보고 싶어요.
- settings.ts에 axios http 요청 및 응답 처리를 위한 함수 생성했으니 확인 부탁드려요!

### 🍰 참고사항
- 아래는 "사진으로 만들기" 버튼 눌렀을 때, 나오는 파일 선택 창입니다.

### 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/d49a8b6f-daa2-43bd-80dc-944035c6920d)

