### PR TITLE
[FEAT] 동화 생성 키워드 선택 페이지 퍼블리싱

### DIFF
--- a/src/components/common/NextBtn.tsx
+++ b/src/components/common/NextBtn.tsx
@@ -3,12 +3,13 @@ import { CommonBtn } from "./common.styled";
 interface NextBtnProps {
   isActive: boolean;
   text: string;
+  width: string;
   handleBtn: () => void;
 }
 
-const NextBtn = ({ isActive, text, handleBtn }: NextBtnProps) => {
+const NextBtn = ({ width, isActive, text, handleBtn }: NextBtnProps) => {
   return (
-    <CommonBtn onClick={handleBtn} isActive={isActive}>
+    <CommonBtn width={width} onClick={handleBtn} isActive={isActive}>
       {text}
     </CommonBtn>
   );

--- a/src/components/selectKeyword/SelectKeyword.styeld.ts
+++ b/src/components/selectKeyword/SelectKeyword.styeld.ts
@@ -1,0 +1,48 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 95%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  gap: 2rem;
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const Title = styled.div`
+  font-size: 2.5rem;
+  font-weight: 800;
+  text-align: center;
+`;
+
+export const KeywordWrapper = styled.div`
+  width: 95%;
+  height: 50%;
+  flex-wrap: wrap;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 1rem;
+`;
+
+export const Keyword = styled.div<{ isSelected: boolean }>`
+  width: 190px;
+  height: 55px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  font-weight: 700;
+  padding: 1rem;
+  border-radius: 10px;
+  background-color: ${({ isSelected }) => (isSelected ? "#fff7cc" : "#f4f4f4")};
+  border: 1px solid ${({ isSelected }) => (isSelected ? "#ffc300" : "#dcdcdc")};
+  cursor: pointer;
+`;

--- a/src/components/selectKeyword/SelectKeyword.tsx
+++ b/src/components/selectKeyword/SelectKeyword.tsx
@@ -1,0 +1,63 @@
+import Header from "@components/common/header/Header";
+import * as S from "./SelectKeyword.styeld";
+import keywordData from "./data.json";
+import NextBtn from "@components/common/NextBtn";
+import { useEffect, useState } from "react";
+
+const SelectKeyword = () => {
+  const result = keywordData.result.map((i) => i.keyword);
+
+  const [selectedKeyword, setSelectedKeyword] = useState<string[]>([]); // 선택된 값들의 배열 관리
+  const [isAcitve, setIsActive] = useState(false);
+
+  const handleClick = (item: string) => {
+    if (selectedKeyword.includes(item)) {
+      setSelectedKeyword(
+        selectedKeyword.filter((selectedItem) => selectedItem !== item)
+      );
+    } else if (selectedKeyword.length >= 3) {
+      alert("최대 3개까지 선택 가능합니다!");
+    } else {
+      setSelectedKeyword([...selectedKeyword, item]);
+    }
+  };
+
+  useEffect(() => {
+    if (selectedKeyword.length > 0) {
+      setIsActive(true);
+    } else {
+      setIsActive(false);
+    }
+  }, [selectedKeyword]);
+
+  return (
+    <>
+      <Header text="동화 만들기" />
+      <S.Wrapper>
+        <S.TitleWrapper>
+          <S.Title>사진에서 단어를 추출했어요</S.Title>
+          <S.Title>원하는 단어를 골라주세요</S.Title>
+        </S.TitleWrapper>
+        <S.KeywordWrapper>
+          {result.map((item, idx) => (
+            <S.Keyword
+              key={idx}
+              isSelected={selectedKeyword.includes(item)}
+              onClick={() => handleClick(item)}
+            >
+              {item}
+            </S.Keyword>
+          ))}
+        </S.KeywordWrapper>
+        <NextBtn
+          width="85%"
+          isActive={isAcitve}
+          text="다음"
+          handleBtn={() => console.log(selectedKeyword)}
+        />
+      </S.Wrapper>
+    </>
+  );
+};
+
+export default SelectKeyword;

--- a/src/components/selectKeyword/SelectKeyword.tsx
+++ b/src/components/selectKeyword/SelectKeyword.tsx
@@ -7,28 +7,28 @@ import { useEffect, useState } from "react";
 const SelectKeyword = () => {
   const result = keywordData.result.map((i) => i.keyword);
 
-  const [selectedKeyword, setSelectedKeyword] = useState<string[]>([]); // 선택된 값들의 배열 관리
-  const [isAcitve, setIsActive] = useState(false);
+  const [selectedKeywordIndices, setSelectedKeywordIndices] = useState<
+    number[]
+  >([]);
+  const [isActive, setIsActive] = useState(false);
 
-  const handleClick = (item: string) => {
-    if (selectedKeyword.includes(item)) {
-      setSelectedKeyword(
-        selectedKeyword.filter((selectedItem) => selectedItem !== item)
+  const handleClick = (index: number) => {
+    if (selectedKeywordIndices.includes(index)) {
+      setSelectedKeywordIndices(
+        selectedKeywordIndices.filter(
+          (selectedIndex) => selectedIndex !== index
+        )
       );
-    } else if (selectedKeyword.length >= 3) {
+    } else if (selectedKeywordIndices.length >= 3) {
       alert("최대 3개까지 선택 가능합니다!");
     } else {
-      setSelectedKeyword([...selectedKeyword, item]);
+      setSelectedKeywordIndices([...selectedKeywordIndices, index]);
     }
   };
 
   useEffect(() => {
-    if (selectedKeyword.length > 0) {
-      setIsActive(true);
-    } else {
-      setIsActive(false);
-    }
-  }, [selectedKeyword]);
+    setIsActive(selectedKeywordIndices.length > 0);
+  }, [selectedKeywordIndices]);
 
   return (
     <>
@@ -42,8 +42,8 @@ const SelectKeyword = () => {
           {result.map((item, idx) => (
             <S.Keyword
               key={idx}
-              isSelected={selectedKeyword.includes(item)}
-              onClick={() => handleClick(item)}
+              isSelected={selectedKeywordIndices.includes(idx)}
+              onClick={() => handleClick(idx)}
             >
               {item}
             </S.Keyword>
@@ -51,9 +51,15 @@ const SelectKeyword = () => {
         </S.KeywordWrapper>
         <NextBtn
           width="85%"
-          isActive={isAcitve}
+          isActive={isActive}
           text="다음"
-          handleBtn={() => console.log(selectedKeyword)}
+          handleBtn={() => {
+            const selectedKeywords = selectedKeywordIndices.map(
+              (index) => result[index]
+            );
+            console.log(selectedKeywords);
+            console.log(selectedKeywordIndices);
+          }}
         />
       </S.Wrapper>
     </>

--- a/src/components/selectKeyword/data.json
+++ b/src/components/selectKeyword/data.json
@@ -1,0 +1,40 @@
+{
+  "result": [
+    {
+      "keyword": "cat"
+    },
+    {
+      "keyword": "dog"
+    },
+    {
+      "keyword": "⭐yujin⭐"
+    },
+    {
+      "keyword": "⭐minji⭐"
+    },
+    {
+      "keyword": "⭐seohyun⭐"
+    },
+    {
+      "keyword": "⭐eunsu⭐"
+    },
+    {
+      "keyword": "⭐hayoung⭐"
+    },
+    {
+      "keyword": "⭐zzalng⭐"
+    },
+    {
+      "keyword": "dog"
+    },
+    {
+      "keyword": "dog"
+    },
+    {
+      "keyword": "dog"
+    },
+    {
+      "keyword": "dog"
+    }
+  ]
+}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -2,7 +2,6 @@ import Dropdown from "@common/dropDown/Dropdown";
 import { DropdownElement } from "@type/dropdown";
 import { useEffect, useState } from "react";
 import { CommonWrapper } from "@common/common.styled";
-import NextBtn from "@components/common/NextBtn";
 
 const nationElements: DropdownElement[] = [
   {
@@ -41,13 +40,6 @@ const OnboardingPage = () => {
   return (
     <CommonWrapper>
       <Dropdown selectList={nationElements} setter={setResult} width="55%" />
-      <NextBtn
-        isActive={result ? true : false}
-        text="다음"
-        handleBtn={() => {
-          console.log("선택완");
-        }}
-      />
     </CommonWrapper>
   );
 };

--- a/src/pages/SelectKeywordPage.tsx
+++ b/src/pages/SelectKeywordPage.tsx
@@ -1,0 +1,7 @@
+import SelectKeyword from "@components/selectKeyword/SelectKeyword";
+
+const SelectKeywordPage = () => {
+  return <SelectKeyword />;
+};
+
+export default SelectKeywordPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,6 +6,7 @@ import SplashScreen from "@pages/SplashScreen";
 import CreatePage from "@pages/CreatePage";
 import KakaoRedirect from "@pages/KakaoRedirect";
 import LearningPage from "@pages/LearningPage";
+import SelectKeywordPage from "@pages/SelectKeywordPage";
 
 const router = createBrowserRouter([
   {
@@ -35,6 +36,10 @@ const router = createBrowserRouter([
   {
     path: "/learning",
     element: <LearningPage />,
+  },
+  {
+    path: "/selectKeyword",
+    element: <SelectKeywordPage />,
   },
 ]);
 


### PR DESCRIPTION
### 👀 관련 이슈
- Resolve: #19 

### ✨ 작업한 내용
- 이미지에서 추출한 키워드 페이지에 나열(더미 데이터 만들어서 맵핑)
- 3개 이상 선택 시 알림 및 선택불가
- 최소 1개 이상 선택해야 다음 버튼 활성화
- 선택한 키워드 색상 변경
- 선택한 키워드 배열 형태로 저장

### 🌀 PR Point
~~현재 SelectKeyword.tsx 파일의 코드를 보면 선택과 동시에 배열에 키워드 값을 저장하고, 배열에 키워드 값이 있다면 isSelected를 true로 바꿔 선택한 키워드 컴포넌트의 색상을 바꾸도록 했는데,,,, 이렇게 하면 혹시 같은 키워드 값이 왔을 때, 하나를 선택하면 그 같은 값을 가진 컴포넌트가 모두 선택 되는 문제가 발생하더라구요. 그래서 제가 고민되는 부분은~~
~~- 키워드가 중복 없이 제공된다면 현재 코드가 더 간결하고 가독성이 좋음~~
~~- 키워드 중복이 없더라도 이런 예외가 발생할 수 있다?를 처리하는게 더 중요하다면 키워드 값은 값대로 저장하고 컴포넌트의 key값으로 색깔 활성화를 시키도록 나눠야 하는데, 코드가 조금 더 길어지고 가독성이 좋아지지 않는 문제가 발생해요.~~

~~2가지 중에 어떻게 하면 더 좋을지 같이 얘기해보면 좋을 것 같아요!~~
고민이 해결되었습니다!

### 🍰 참고사항

- [ ] 선택된게 하나도 없을 때, 버튼 text 변경하기

### 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/ae6b71e7-a783-4688-af92-9d7ae80a9588)

![image](https://github.com/user-attachments/assets/0ca27bfa-1602-4b1e-8023-d4ba73d128ff)