### PR TITLE
[FEAT] 동화 읽기 페이지 퍼블리싱

### DIFF
--- a/src/components/tales/readTale/ReadTale.styled.ts
+++ b/src/components/tales/readTale/ReadTale.styled.ts
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 95%;
+  height: 90%;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const ReadTaleHead = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 2.8rem 0;
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const Title = styled.div`
+  font-size: 2.5rem;
+  font-weight: 800;
+`;
+
+export const Complete = styled.div`
+  font-size: 1.7rem;
+  font-weight: 500;
+  color: #f7a300;
+`;
+
+export const TaleWrapper = styled.div`
+  width: 100%;
+  height: 75%;
+  max-height: 75%;
+  overflow-y: scroll;
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+`;
+
+export const BtnWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;

--- a/src/components/tales/readTale/ReadTale.tsx
+++ b/src/components/tales/readTale/ReadTale.tsx
@@ -1,0 +1,57 @@
+import Header from "@components/common/header/Header";
+import * as S from "./ReadTale.styled";
+import Dropdown from "@components/common/dropDown/Dropdown";
+import { nationElements } from "@pages/OnboardingPage";
+import { useState } from "react";
+import NextBtn from "@components/common/NextBtn";
+import LoadingScreen from "@components/common/spinner/LoadingScreen";
+
+const ReadTale = () => {
+  const [result, setResult] = useState<string | number | null>(null);
+  const data = null;
+
+  const onClick = () => {
+    console.log(result);
+  };
+  return (
+    <>
+      <Header text="동화 읽기" />
+      <S.Wrapper>
+        {data ? (
+          <>
+            <S.ReadTaleHead>
+              <S.TitleWrapper>
+                <S.Complete>동화가 완성되었어요!</S.Complete>
+                <S.Title>제목: 사과나무와 작은 동물들</S.Title>
+              </S.TitleWrapper>
+              <Dropdown
+                selectList={nationElements}
+                setter={setResult}
+                width="30%"
+              />
+            </S.ReadTaleHead>
+            <S.TaleWrapper></S.TaleWrapper>
+            <S.BtnWrapper>
+              <NextBtn
+                width="48%"
+                isActive={true}
+                text="음성으로 듣기"
+                handleBtn={onClick}
+              />
+              <NextBtn
+                width="48%"
+                isActive={true}
+                text="학습하기"
+                handleBtn={onClick}
+              />
+            </S.BtnWrapper>
+          </>
+        ) : (
+          <LoadingScreen text="동화" />
+        )}
+      </S.Wrapper>
+    </>
+  );
+};
+
+export default ReadTale;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,7 @@ import KakaoRedirect from "@pages/KakaoRedirect";
 import LearningPage from "@pages/LearningPage";
 import SelectKeywordPage from "@pages/SelectKeywordPage";
 import TaleDetailPage from "@pages/TaleDetailPage";
+import ReadTale from "@components/tales/readTale/ReadTale";
 
 const router = createBrowserRouter([
   {
@@ -45,6 +46,10 @@ const router = createBrowserRouter([
   {
     path: "/taleDetail",
     element: <TaleDetailPage />,
+  },
+  {
+    path: "/readTale",
+    element: <ReadTale />,
   },
 ]);
 


### PR DESCRIPTION
### 👀 관련 이슈
- Resolve: #26 

### ✨ 작업한 내용
- 동화 생성 페이지 퍼블리싱
- 동화 생성 시간에는 로딩 페이지 출력

### 🌀 PR Point
페이지마다 동화 생성에 필요한 부분들을 props로 넘겨서 최종적으로 body에 담아 동화 생성 api를 호출하려고 했는데, 매번 라우팅이 달라져야 할 것 같아서 쿼리스트링으로 페이지 마다 전송해서 최종 생성 전 페이지에서 body에 담아 호출하는 방식으로 진행할게요!


### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/297eb206-a215-4f93-aa4a-d2a5ee335d7a)

