### PR TITLE
[FEAT] 동화 설정 데이터 저장 및 API 연결

### DIFF
--- a/src/apis/authAxois.ts
+++ b/src/apis/authAxois.ts
@@ -54,11 +54,12 @@ export const getAuthAxios = (token: string | null) => {
       return response;
     },
     async (error) => {
-      alert("토큰이 만료되었습니다. 재로그인 후 시도해주세요!");
-      LocalStorage.removeItem("access");
-      LocalStorage.removeItem("refresh");
-      window.location.href = "/login";
-      return Promise.reject(error); // 에러 전달
+      throw error;
+      // alert("토큰이 만료되었습니다. 재로그인 후 시도해주세요!");
+      // LocalStorage.removeItem("access");
+      // LocalStorage.removeItem("refresh");
+      // window.location.href = "/login";
+      // return Promise.reject(error); // 에러 전달
     }
   );
 

--- a/src/apis/createTales.ts
+++ b/src/apis/createTales.ts
@@ -1,21 +1,42 @@
 import LocalStorage from "@utils/localStorage";
 import { getAuthAxios } from "./authAxois";
+import { CreateTaleData } from "@type/createTale";
+// import { Server } from "./settings";
+import axios from "axios";
 
 const baseURL = import.meta.env.VITE_PUBLIC_SERVER_URL;
 
-export const createWithImg = async (body: FormData): Promise<string[]> => {
+export const createKeyword = async (body: FormData): Promise<string[]> => {
   try {
-    const access = LocalStorage.getItem('access');
+    const access = LocalStorage.getItem("access");
     const authAxios = getAuthAxios(access);
     const response = await authAxios.post(`${baseURL}/tales/keyword`, body, {
       headers: {
         "Content-Type": "multipart/form-data",
       },
     });
-    console.log(response.data);
+
+    // response에서 keyword만 추출하여 배열에 담아 return
+    const keywords: string[] = response.data.result.map(
+      (item: { keyword: string }) => item.keyword
+    );
+
+    return keywords;
+  } catch (error) {
+    alert(
+      "이미지 화질이 안좋거나, 추출된 키워드가 없습니다. 다시 이미지를 업로드하세요!"
+    );
+    throw error;
+  }
+};
+
+export const createTale = async (body: CreateTaleData) => {
+  try {
+    const access = LocalStorage.getItem("access");
+    const authAxios = getAuthAxios(access);
+    const response = await authAxios.post(`${baseURL}/tales/`, body);
     return response.data;
   } catch (error) {
-    alert("동화 생성 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
     throw error;
   }
 };

--- a/src/apis/createTales.ts
+++ b/src/apis/createTales.ts
@@ -2,7 +2,6 @@ import LocalStorage from "@utils/localStorage";
 import { getAuthAxios } from "./authAxois";
 import { CreateTaleData } from "@type/createTale";
 // import { Server } from "./settings";
-import axios from "axios";
 
 const baseURL = import.meta.env.VITE_PUBLIC_SERVER_URL;
 

--- a/src/components/tales/createMain/CreateMain.tsx
+++ b/src/components/tales/createMain/CreateMain.tsx
@@ -3,23 +3,37 @@ import * as S from "./CreateMain.styled";
 import SelectOption from "./SelectOption/SelectOption";
 import TabBar from "@components/common/tabBar/TabBar";
 import { CommonTitle } from "@components/common/common.styled";
+import { useState } from "react";
+import LoadingSpinner from "@components/common/spinner/LoadingSpinner";
 
 const CreateMain = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
   return (
     <>
-      <Header text="동화 만들기" />
-      <S.Wrapper>
-        <img src="/topGraphic.png" id="topGraphic" />
-        <S.SelectContainer>
-          <CommonTitle>동화를 만들어볼까요?</CommonTitle>
-          <S.OptionContainer>
-            <SelectOption text="사진으로" imgURL="/picture.png" />
-            <SelectOption text="글로" imgURL="/text.png" />
-          </S.OptionContainer>
-        </S.SelectContainer>
-        <img src="/btmGraphic.png" id="btmGraphic" />
-      </S.Wrapper>
-      <TabBar />
+      {isLoading ? (
+        <LoadingSpinner />
+      ) : (
+        <>
+          <Header text="동화 만들기" />
+          <S.Wrapper>
+            <img src="/topGraphic.png" id="topGraphic" />
+            <S.SelectContainer>
+              <CommonTitle>동화를 만들어볼까요?</CommonTitle>
+              <S.OptionContainer>
+                <SelectOption
+                  text="사진으로"
+                  imgURL="/picture.png"
+                  setIsLoading={setIsLoading}
+                />
+                <SelectOption text="글로" imgURL="/text.png" />
+              </S.OptionContainer>
+            </S.SelectContainer>
+            <img src="/btmGraphic.png" id="btmGraphic" />
+          </S.Wrapper>
+          <TabBar />
+        </>
+      )}
     </>
   );
 };

--- a/src/components/tales/createMain/SelectOption/InputImg.tsx
+++ b/src/components/tales/createMain/SelectOption/InputImg.tsx
@@ -1,19 +1,20 @@
 import { ChangeEvent } from "react";
 import * as S from "./SelectOption.styled";
-import { createWithImg } from "../../../../apis/createTales";
+import { createKeyword } from "../../../../apis/createTales";
+import { useNavigate } from "react-router-dom";
+import { InputImgProps } from "@type/selectOption";
 
-const InputImg = () => {
+const InputImg = ({ setIsLoading }: InputImgProps) => {
+  const navigate = useNavigate();
+
   const insertImg = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const formData = new FormData();
       formData.append("file", file);
-      try {
-        const result = await createWithImg(formData);
-        console.log(result);
-      } catch (error) {
-        console.error("파일 업로드 중 오류 발생:", error);
-      }
+      if (setIsLoading) setIsLoading(true);
+      const keywords: string[] = await createKeyword(formData);
+      navigate("/selectKeyword", { state: { keywords } });
     }
   };
   return (

--- a/src/components/tales/createMain/SelectOption/SelectOption.tsx
+++ b/src/components/tales/createMain/SelectOption/SelectOption.tsx
@@ -2,12 +2,12 @@ import { SelectOptionProps } from "@type/selectOption";
 import * as S from "./SelectOption.styled";
 import InputImg from "./InputImg";
 
-const SelectOption = ({ text, imgURL }: SelectOptionProps) => {
+const SelectOption = ({ text, imgURL, setIsLoading }: SelectOptionProps) => {
   if (text.includes("사진")) {
     return (
       <S.ImgLabel htmlFor="imageInput">
         <S.Wrapper>
-          <InputImg />
+          <InputImg setIsLoading={setIsLoading} />
           <S.ImgBox>
             <img src={imgURL} />
           </S.ImgBox>

--- a/src/components/tales/readTale/ReadTale.tsx
+++ b/src/components/tales/readTale/ReadTale.tsx
@@ -2,17 +2,36 @@ import Header from "@components/common/header/Header";
 import * as S from "./ReadTale.styled";
 import Dropdown from "@components/common/dropDown/Dropdown";
 import { nationElements } from "@pages/OnboardingPage";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import NextBtn from "@components/common/NextBtn";
 import LoadingScreen from "@components/common/spinner/LoadingScreen";
+import { createTale } from "@apis/createTales";
+import { useLocation } from "react-router-dom";
+import { CreateTaleData } from "@type/createTale";
 
 const ReadTale = () => {
+  const location = useLocation();
+  const state = location.state as { requestData?: CreateTaleData };
+  const requestData = state.requestData;
+
   const [result, setResult] = useState<string | number | null>(null);
-  const data = null;
+  const [data, setData] = useState(null);
 
   const onClick = () => {
     console.log(result);
   };
+
+  useEffect(() => {
+    const getTale = async () => {
+      if (requestData) {
+        const response = await createTale(requestData);
+        setData(response);
+        console.log(response);
+      }
+    };
+    getTale();
+  }, []);
+
   return (
     <>
       <Header text="동화 읽기" />

--- a/src/components/tales/readTale/ReadTale.tsx
+++ b/src/components/tales/readTale/ReadTale.tsx
@@ -7,12 +7,10 @@ import NextBtn from "@components/common/NextBtn";
 import LoadingScreen from "@components/common/spinner/LoadingScreen";
 import { createTale } from "@apis/createTales";
 import { useLocation } from "react-router-dom";
-import { CreateTaleData } from "@type/createTale";
 
 const ReadTale = () => {
   const location = useLocation();
-  const state = location.state as { requestData?: CreateTaleData };
-  const requestData = state.requestData;
+  const { requestData } = location.state || {};
 
   const [result, setResult] = useState<string | number | null>(null);
   const [data, setData] = useState(null);

--- a/src/components/tales/selectKeyword/SelectKeyword.tsx
+++ b/src/components/tales/selectKeyword/SelectKeyword.tsx
@@ -1,12 +1,15 @@
 import Header from "@components/common/header/Header";
 import * as S from "./SelectKeyword.styeld";
-import keywordData from "./data.json";
 import NextBtn from "@components/common/NextBtn";
 import { useEffect, useState } from "react";
 import { CommonTitle } from "@components/common/common.styled";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const SelectKeyword = () => {
-  const result = keywordData.result.map((i) => i.keyword);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const { keywords } = location.state || {};
 
   const [selectedKeywordIndices, setSelectedKeywordIndices] = useState<
     number[]
@@ -14,7 +17,14 @@ const SelectKeyword = () => {
   const [isActive, setIsActive] = useState(false);
   const [btnText, setBtnText] = useState<string>("단어를 선택해주세요");
 
-  const handleClick = (index: number) => {
+  useEffect(() => {
+    if (selectedKeywordIndices.length > 0) {
+      setIsActive(true);
+      setBtnText("다음");
+    }
+  }, [selectedKeywordIndices]);
+
+  const handleComponents = (index: number) => {
     if (selectedKeywordIndices.includes(index)) {
       setSelectedKeywordIndices(
         selectedKeywordIndices.filter(
@@ -28,13 +38,12 @@ const SelectKeyword = () => {
     }
   };
 
-  useEffect(() => {
-    if (selectedKeywordIndices.length > 0) {
-      setIsActive(true);
-      setBtnText("다음");
-    }
-  }, [selectedKeywordIndices]);
-
+  const handleNextBtn = () => {
+    const selectKeywords = selectedKeywordIndices.map(
+      (index) => keywords[index]
+    );
+    navigate("/taleDetail", { state: { selectKeywords } });
+  };
   return (
     <>
       <Header text="동화 만들기" />
@@ -44,27 +53,22 @@ const SelectKeyword = () => {
           <CommonTitle>원하는 단어를 골라주세요</CommonTitle>
         </S.TitleWrapper>
         <S.KeywordWrapper>
-          {result.map((item, idx) => (
-            <S.Keyword
-              key={idx}
-              isSelected={selectedKeywordIndices.includes(idx)}
-              onClick={() => handleClick(idx)}
-            >
-              {item}
-            </S.Keyword>
-          ))}
+          {keywords &&
+            keywords.map((item: string, idx: number) => (
+              <S.Keyword
+                key={idx}
+                isSelected={selectedKeywordIndices.includes(idx)}
+                onClick={() => handleComponents(idx)}
+              >
+                {item}
+              </S.Keyword>
+            ))}
         </S.KeywordWrapper>
         <NextBtn
           width="85%"
           isActive={isActive}
           text={btnText}
-          handleBtn={() => {
-            const selectedKeywords = selectedKeywordIndices.map(
-              (index) => result[index]
-            );
-            console.log(selectedKeywords);
-            console.log(selectedKeywordIndices);
-          }}
+          handleBtn={handleNextBtn}
         />
       </S.Wrapper>
     </>

--- a/src/components/tales/taleDetail/TaleDetail.tsx
+++ b/src/components/tales/taleDetail/TaleDetail.tsx
@@ -4,8 +4,14 @@ import Dropdown from "@components/common/dropDown/Dropdown";
 import { nationElements } from "@pages/OnboardingPage";
 import { useEffect, useState } from "react";
 import NextBtn from "@components/common/NextBtn";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const TaleDetail = () => {
+  const location = useLocation();
+  const { selectKeywords } = location.state || {};
+
+  const navigate = useNavigate();
+
   const [mood, setMood] = useState<string | number | null>(null);
   const [characters, setCharacters] = useState<string | number | null>(null);
   const [contents, setContents] = useState<string | number | null>(null);
@@ -13,7 +19,8 @@ const TaleDetail = () => {
   const [btnText, setBtnText] = useState<string>("단어를 선택해주세요");
 
   const result: (string | number | null)[] = [mood, characters, contents];
-
+  const detail = "구체적";
+  const chr = ["최재영"];
   const isFormValid = () => result.every((value) => value !== null);
 
   useEffect(() => {
@@ -28,16 +35,13 @@ const TaleDetail = () => {
 
   const handleBtn = async () => {
     const requestData = {
+      detail,
+      keywords: selectKeywords,
       mood,
-      characters,
+      characters: chr,
       contents,
     };
-
-    try {
-      console.log(requestData);
-    } catch (error) {
-      throw error;
-    }
+    navigate("/readTale", { state: { requestData } });
   };
 
   return (

--- a/src/type/createTale.d.ts
+++ b/src/type/createTale.d.ts
@@ -1,0 +1,7 @@
+export interface CreateTaleData {
+  detail: string;
+  keywords?: string[];
+  mood: string | number | null;
+  characters: string | number | null[];
+  contents: string | number | null;
+}

--- a/src/type/selectOption.d.ts
+++ b/src/type/selectOption.d.ts
@@ -1,4 +1,8 @@
-export interface SelectOptionProps {
+export interface SelectOptionProps extends InputImgProps {
   imgURL: string;
   text: string;
+}
+
+export interface InputImgProps {
+  setIsLoading?: React.Dispatch<React.SetStateAction<boolean>>;
 }


### PR DESCRIPTION
### 👀 관련 이슈
- Resolve: #28 

### ✨ 작업한 내용
- 이미지 전송 후에 받는 키워드들을 키워드 선택 페이지로 전송
- 키워드 선택 페이지에서 선택된 키워드들 배열에 담아서 상세 설정 페이지로 전송
- 상세 설정 페이지에서 선택된 값들과 받아온 키워드를 requestData에 담아 api 호출
- api 호출하여 받은 동화를 동화 읽기 페이지에서 출력

### 🌀 PR Point
- 현재 동화 생성이 안되는데 드롭다운 요소들 정리 후 다시 생성하겠습니다

